### PR TITLE
Minimal addition to Parallel Text

### DIFF
--- a/components/functionalequivalents/FunctionalEquivalentsTable-metadata.json
+++ b/components/functionalequivalents/FunctionalEquivalentsTable-metadata.json
@@ -22,7 +22,8 @@
                 "name": "FunctionalEquivalentsSet_ID",
                 "required": true,
                 "propertyUrl": "http://cldf.clld.org/v1.0/terms.rdf#functionalEquivalentsSetReference",
-                "datatype": "string"
+                "datatype": "string",
+                "separator": " "
             },
             {
                 "name": "Segment_Slice",

--- a/components/functionalequivalents/README.md
+++ b/components/functionalequivalents/README.md
@@ -9,7 +9,9 @@ Such a functional alignment is in principle similar to a cognacy alignment (see 
 
 ## Explicit stand-off reference
 
-In this method, the string ('sentence'), encoded as a link to a [`FormTable`](../forms) in the column `Form_ID`, is assumed to be separated by spaces. Using the column `Segment_Slice` any set of such elements ('words') can be specified by their order-count (i.e. elements "3:5 7", referring to the third to fifth and seventh 'word'). One line in the `FunctionalEquivalentsTable` specifies such a group of words, and assigns it to a `FunctionalEquivalentsSet_ID`, i.e. a group of lines in the table that express a similar function. Further information about these sets can be specified in the [`functionalEquivalentsSetsTable`]{../functionalequivalentssets}.
+In this method, the string ('sentence'), encoded as a link to a [`FormTable`](../forms) in the column `Form_ID`, is assumed to be separated by spaces. Using the column `Segment_Slice` any set of such elements ('words') can be specified by their order-count (i.e. elements "3:5 7", referring to the third to fifth and seventh 'word'). One line in the `FunctionalEquivalentsTable` specifies such a group of words, and assigns it to a `FunctionalEquivalentsSet_ID`, i.e. a group of lines in the table that express a similar function. To obtain full generality, it is possible to assign a list of IDs separated by spaces.
+
+Further information about these sets can be specified in the [`functionalEquivalentsSetsTable`]{../functionalequivalentssets}.
 
 Note that this approach cannot deal with subparts of words. If you want to refer to, say, the first two letters of a word, then this part has to be separated separately. This means that first a new [`FormTable`](../forms) has to be made with a new separation (e.g. a morpheme separation). This can of course also be done via the [examples component](../examples).
 


### PR DESCRIPTION
I forgot this small addition, so please consider: The `FunctionalEquivalentset_ID` can be a list of IDs separated by spaces. I was just preparing some examples for another project, and I realised this will be highly useful for special cases.

It shouldn't conflict with anything else. I added a small note to the readme as well